### PR TITLE
Make sure to search for package.json in cwd

### DIFF
--- a/inlineRequireModules.js
+++ b/inlineRequireModules.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const { experiences } = JSON.parse(
   fs.readFileSync(
     require.resolve("./package.json", {
-      paths: module.parent && module.parent.paths
+      paths: [".", ...(module.parent ? module.parent.paths : [])]
     }),
     "utf8"
   )


### PR DESCRIPTION
This is implicit in node v10, but requires explicitly adding . to the
search path in v12.